### PR TITLE
Add missing informative syntax error

### DIFF
--- a/docs/0.8.9/tutorial/tour.html
+++ b/docs/0.8.9/tutorial/tour.html
@@ -157,7 +157,7 @@ as well see now what happens in that case and what you can do to fix
 the error.</p>
 <p>Open up the config again and introduce a syntax error by removing the first
 single quote in the two lines you changed, so they read:</p>
-<div class="highlight-python"><div class="highlight"><pre><span class="n">c</span><span class="p">[</span><span class="s">&#39;title&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s">&quot;Pyflakes&quot;</span>
+<div class="highlight-python"><div class="highlight"><pre><span class="n">c</span><span class="p">[</span><span class="s">title&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s">&quot;Pyflakes&quot;</span>
 <span class="n">c</span><span class="p">[</span><span class="s">&#39;titleURL&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="s">&quot;http://divmod.org/trac/wiki/DivmodPyflakes&quot;</span>
 </pre></div>
 </div>


### PR DESCRIPTION
The config file shoud include a syntax error otherwise it will not trigger the master configuration error explained later.

By the way... where  is the real source of this page? How is this page generated?
