### PR TITLE
Numbering sections so readers know where they are

### DIFF
--- a/docs/0.8.12/_sources/index.txt
+++ b/docs/0.8.12/_sources/index.txt
@@ -12,6 +12,7 @@ Table Of Contents
 
 .. toctree::
    :maxdepth: 2
+   :numbered:
 
    tutorial/index
    manual/index


### PR DESCRIPTION
It helps readers to have numbered section in the doc so that they can keep track of where they are.